### PR TITLE
Exclude static fields from generated Avro Schema + tests

### DIFF
--- a/AvroSchemaGenerator.Tests/GetSchemaTest.cs
+++ b/AvroSchemaGenerator.Tests/GetSchemaTest.cs
@@ -94,6 +94,15 @@ namespace AvroSchemaGenerator.Tests
 
             Assert.Equal(expectSchema, actual);
         }
+        [Fact]
+        public void TestStaticFieldsAreIgnored()
+        {
+            var expectSchema = "{\"type\":\"record\",\"namespace\":\"AvroSchemaGenerator.Tests\",\"name\":\"SimpleWithStaticFieldsAndNestedClass\",\"fields\":[{\"name\":\"FactTime\",\"type\":\"long\"},{\"name\":\"SimpleStaticInner\",\"type\":[\"null\",{\"type\":\"record\",\"namespace\":\"AvroSchemaGenerator.Tests\",\"name\":\"SimpleWithStaticFields\",\"fields\":[{\"name\":\"Name\",\"type\":[\"null\",\"string\"],\"default\":null}]}],\"default\":null}]}";
+            var actual = typeof(SimpleWithStaticFieldsAndNestedClass).GetSchema();
+            _output.WriteLine(actual);
+
+            Assert.Equal(expectSchema, actual);
+        }
     }
 
     public class SimpleFoo
@@ -275,4 +284,23 @@ namespace AvroSchemaGenerator.Tests
         Avi,
         Mp4
     }
+
+    public class SimpleWithStaticFields
+    {
+        private static readonly string _staticFieldOnInner = "a field";
+        public static string StaticFieldOnInner => _staticFieldOnInner;
+
+        public string Name { get; set; }
+    }
+
+    public class SimpleWithStaticFieldsAndNestedClass
+    {
+        private static readonly string _staticField = "a field";
+        public static string StaticField => _staticField;
+
+        public long FactTime { get; set; }
+
+        public SimpleWithStaticFields SimpleStaticInner { get; set; }
+    }
+
 }

--- a/SchemaGenerator/GenerateSchema.cs
+++ b/SchemaGenerator/GenerateSchema.cs
@@ -26,7 +26,7 @@ namespace AvroSchemaGenerator
                 schema["aliases"] = aliases;
             }
             schema["fields"] = new List<Dictionary<string, object>>();
-            var properties = type.GetProperties();
+            var properties = type.GetProperties(BindingFlags.Instance | BindingFlags.Public) ;
             foreach (var p in properties)
             {
                 if(!ShouldIgnore(p))
@@ -402,7 +402,7 @@ namespace AvroSchemaGenerator
                 {"type", "record"}, {"namespace", property.PropertyType.Namespace}, {"name", property.PropertyType.Name}
             };
             var aliases = GetAliases(property);
-            var properties = property.PropertyType.GetProperties();
+            var properties = property.PropertyType.GetProperties(BindingFlags.Instance | BindingFlags.Public);
             var fieldProperties = new List<Dictionary<string, object>>();
             foreach (var p in properties)
             {
@@ -473,7 +473,7 @@ namespace AvroSchemaGenerator
             {
                 {"type", "record"}, {"namespace", property.PropertyType.Namespace}, {"name", property.PropertyType.Name}
             };
-            var properties = property.PropertyType.GetProperties();
+            var properties = property.PropertyType.GetProperties(BindingFlags.Instance | BindingFlags.Public);
             var fieldProperties = new List<Dictionary<string, object>>();
             foreach (var p in properties)
             {
@@ -550,7 +550,7 @@ namespace AvroSchemaGenerator
             var aliases = GetAliases(property);
             if (aliases != null)
                 schema["aliases"] = aliases;
-            var properties = property.GetProperties();
+            var properties = property.GetProperties(BindingFlags.Instance | BindingFlags.Public);
             var fieldProperties = new List<Dictionary<string, object>>();
             foreach (var p in properties)
             {


### PR DESCRIPTION
Following https://stackoverflow.com/questions/13522132/how-to-exclude-static-property-when-using-getproperties-method for excluding static fields.