### PR TITLE
Add Custom AVRO definition support

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,20 @@ public class MessageDateKind
 }
 ```
 
+## Custom Avro Definition
+```csharp
+public class CustomDefinition
+{
+    [AvroSchema("{\n" +
+                "  \"type\": \"bytes\",\n" +
+                "  \"logicalType\": \"decimal\",\n" +
+                "  \"precision\": 10,\n" +
+                "  \"scale\": 6\n" +
+                "}")]
+    public AvroDecimal DecimalAvro { get; set; }
+}
+```
+
 ## NOTE
 - Don't use same declaring type as dictionary value
 - Don't use same declaring type as list argument

--- a/SchemaGenerator/Attributes/AvroSchema.cs
+++ b/SchemaGenerator/Attributes/AvroSchema.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace AvroSchemaGenerator.Attributes
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public class AvroSchemaAttribute : Attribute
+    {
+        public string Value { get; }
+
+        public AvroSchemaAttribute(string value)
+        {
+            Value = value;
+        }
+    }
+}

--- a/SchemaGenerator/DefaultValue.cs
+++ b/SchemaGenerator/DefaultValue.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Reflection;
-using System.Text;
+using AvroSchemaGenerator.Attributes;
 
 namespace AvroSchemaGenerator
 {
@@ -24,6 +22,10 @@ namespace AvroSchemaGenerator
         {
             return property.GetCustomAttribute(typeof(RequiredAttribute)) != null;
         }
-        
+
+        public static string GetAvroCustomDefinition(this PropertyInfo property)
+        {
+            return ((AvroSchemaAttribute) property.GetCustomAttribute(typeof(AvroSchemaAttribute)))?.Value;
+        }
     }
 }


### PR DESCRIPTION
Fix https://github.com/eaba/AvroSchemaGenerator/issues/70

This PR adds support for custom Avro definition just like the java side does:
```java
@org.apache.avro.reflect.AvroSchema("{ \"type\": \"bytes\", \"logicalType\": \"decimal\", \"precision\": 4, \"scale\": 2 }")
public BigDecimal decimal;
```

After this PR gets merged, we can then use the `AvroSchema` attribute to custom the type definition like below:
```csharp
public class CustomDefinition
{
    [AvroSchema("{\n" +
                "  \"type\": \"bytes\",\n" +
                "  \"logicalType\": \"decimal\",\n" +
                "  \"precision\": 10,\n" +
                "  \"scale\": 6\n" +
                "}")]
    public AvroDecimal DecimalAvro { get; set; }
}
```
