### PR TITLE
Add support for Guid type

### DIFF
--- a/AvroSchemaGenerator.Tests/FullSchemaTest.cs
+++ b/AvroSchemaGenerator.Tests/FullSchemaTest.cs
@@ -275,6 +275,21 @@ namespace AvroSchemaGenerator.Tests
             _output.WriteLine(actual);
             Assert.Equal(expected, actual);
         }
+
+        class WithGuidType
+        {
+            [Required]
+            public Guid Id { get; set; }
+        }
+        [Fact]
+        public void TestGuidType() 
+        {
+            var expected = "{\"namespace\":\"AvroSchemaGenerator.Tests\",\"name\":\"WithGuidType\",\"type\":\"record\",\"fields\":[{\"name\":\"Id\",\"type\":{\"type\":\"string\",\"logicalType\":\"uuid\"}}]}";
+            var actual = typeof(WithGuidType).GetSchema();
+            _output.WriteLine(actual);
+            Assert.Equal(expected, actual);
+
+        }
         private sbyte[] Write<T>(T message, ReflectWriter<T> writer)
         {
             var ms = new MemoryStream();

--- a/SchemaGenerator/GenerateSchema.cs
+++ b/SchemaGenerator/GenerateSchema.cs
@@ -1593,6 +1593,12 @@ namespace AvroSchemaGenerator
                     {
                         {"type", "bytes"}, {"logicalType", "decimal"}, {"precision", 4}, {"scale", 2}
                     };
+                case "Guid":
+                    return new Dictionary<string, object>
+                    {
+                        {"type", "string"}, {"logicalType", "uuid"}
+                    };
+
                 default:
                     throw new ArgumentException($"{type} not supported");
             }


### PR DESCRIPTION
The Guid type in .NET logically maps the the AVRO UUID type.

See https://avro.apache.org/docs/1.11.1/specification/#uuid for reference and
https://github.com/apache/avro/blob/7c17fd534b477236a9a1b635a5375c99ce811e94/lang/csharp/src/apache/test/AvroGen/AvroGenSchemaTests.cs#L691 for a c# reference from upstream avro generation.

As this is a simple usage of string with a logical type it is pretty straight forward to add.